### PR TITLE
Added move version of set_body for performance (Issue #999)

### DIFF
--- a/test/connection/connection.cpp
+++ b/test/connection/connection.cpp
@@ -30,6 +30,8 @@
 
 #include "connection_tu2.hpp"
 
+#include <algorithm>
+
 // Include special debugging transport
 //#include <websocketpp/config/minimal_client.hpp>
 #include <websocketpp/transport/debug/endpoint.hpp>
@@ -172,6 +174,20 @@ void http_func(server* s, websocketpp::connection_hdl hdl) {
     BOOST_CHECK_EQUAL(con->get_response_msg(), status_code::get_string(status_code::ok));
 }
 
+void http_func_with_move(server* s, websocketpp::connection_hdl hdl) {
+    using namespace websocketpp::http;
+
+    server::connection_ptr con = s->get_con_from_hdl(hdl);
+
+    std::string res = con->get_resource();
+
+    con->set_body( std::move(res) );
+    con->set_status(status_code::ok);
+
+    BOOST_CHECK_EQUAL(con->get_response_code(), status_code::ok);
+    BOOST_CHECK_EQUAL(con->get_response_msg(), status_code::get_string(status_code::ok));
+}
+
 void defer_http_func(server* s, bool * deferred, websocketpp::connection_hdl hdl) {
     *deferred = true;
     
@@ -233,6 +249,18 @@ BOOST_AUTO_TEST_CASE( http_request ) {
 
     server s;
     s.set_http_handler(bind(&http_func,&s,::_1));
+
+    BOOST_CHECK_EQUAL(run_server_test(s,input), output);
+}
+
+BOOST_AUTO_TEST_CASE( http_request_with_move ) {
+    std::string input = "GET /foo/bar HTTP/1.1\r\nHost: www.example.com\r\nOrigin: http://www.example.com\r\n\r\n";
+    std::string output = "HTTP/1.1 200 OK\r\nContent-Length: 8\r\nServer: ";
+    output+=websocketpp::user_agent;
+    output+="\r\n\r\n/foo/bar";
+
+    server s;
+    s.set_http_handler(bind(&http_func_with_move,&s,::_1));
 
     BOOST_CHECK_EQUAL(run_server_test(s,input), output);
 }

--- a/websocketpp/connection.hpp
+++ b/websocketpp/connection.hpp
@@ -1041,6 +1041,7 @@ public:
      * @see websocketpp::http::response::set_body
      */
     void set_body(std::string const & value);
+    void set_body(std::string && value);
 
     /// Append a header
     /**

--- a/websocketpp/connection.hpp
+++ b/websocketpp/connection.hpp
@@ -1041,7 +1041,7 @@ public:
      * @see websocketpp::http::response::set_body
      */
     void set_body(std::string const & value);
-    void set_body(std::string && value);
+    void set_body( std::string&& value );
 
     /// Append a header
     /**

--- a/websocketpp/impl/connection_impl.hpp
+++ b/websocketpp/impl/connection_impl.hpp
@@ -576,7 +576,7 @@ void connection<config>::set_body(std::string const & value) {
 }
 
 template <typename config>
-void connection<config>::set_body( std::string && value )
+void connection<config>::set_body( std::string&& value )
 {
    if (m_internal_state != istate::PROCESS_HTTP_REQUEST) {
        throw exception("Call to set_status from invalid state",

--- a/websocketpp/impl/connection_impl.hpp
+++ b/websocketpp/impl/connection_impl.hpp
@@ -575,6 +575,17 @@ void connection<config>::set_body(std::string const & value) {
     m_response.set_body(value);
 }
 
+template <typename config>
+void connection<config>::set_body( std::string && value )
+{
+   if (m_internal_state != istate::PROCESS_HTTP_REQUEST) {
+       throw exception("Call to set_status from invalid state",
+                     error::make_error_code(error::invalid_state));
+   }
+
+   m_response.set_body(std::move(value));
+}
+
 // TODO: EXCEPTION_FREE
 template <typename config>
 void connection<config>::append_header(std::string const & key,


### PR DESCRIPTION
This PR is a suggested fix for https://github.com/bitshares/bitshares-core/issues/999

This is a small addition to websocketpp to allow set_body to be called with an r-value reference. This can increase performance.

This was back-ported from https://github.com/EOSIO/eos/pull/3240

- [x] Create test